### PR TITLE
Use "Standard" instance type for Web Service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -58,7 +58,7 @@ services:
 - type: web
   name: zulip
   env: docker
-  plan: starter plus
+  plan: standard
   dockerfilePath: ./docker-zulip/Dockerfile
   autoDeploy: false
   disk:

--- a/render.yaml
+++ b/render.yaml
@@ -82,7 +82,7 @@ services:
     - key: SETTING_EMAIL_USE_TLS
       value: True
     - key: QUEUE_WORKERS_MULTIPROCESS
-      value: False # set to True if Zulip plan is standard plus or greater
+      value: False # set to True if Zulip plan is pro or greater
     - key: ZULIP_AUTH_BACKENDS
       value: 'EmailAuthBackend' # Zulip supports other authentication methods https://zulip.readthedocs.io/en/latest/production/authentication-methods.html
     - key: SECRETS_secret_key


### PR DESCRIPTION
Let's give more RAM to the Web Service.